### PR TITLE
Fix build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: build
 on: 
   push:
     branches:
-      - '*'
+      - 'develop'
+  pull_request:
   release:
     types: [published]
 


### PR DESCRIPTION
トリガーするイベントを変更
Cause: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache